### PR TITLE
Update api url to 'https://api.postcode.eu/nl/v1' and end point to 'a…

### DIFF
--- a/postcodepy/postcodepy.py
+++ b/postcodepy/postcodepy.py
@@ -31,7 +31,7 @@ class EndpointsMixin(object):
         returns :
             a response dictionary
         """
-        endpoint = 'rest/addresses/%s/%s' % (postcode, nr)
+        endpoint = 'addresses/postcode/%s/%s' % (postcode, nr)
         if addition:
             endpoint += '/' + addition
 
@@ -104,7 +104,7 @@ class API(EndpointsMixin, object):
         if environment == 'practice':
             raise PostcodeError("ERRnoPractice")
         elif environment == 'live':
-            self.api_url = 'https://api.postcode.nl'
+            self.api_url = 'https://api.postcode.eu/nl/v1'
 
         self.client = requests.Session()
 


### PR DESCRIPTION
In response to the following message from postcode.nl I changed the api url and endpoint.

Om dit te doen kun je migreren naar het api.postcode.eu domein. Pas hiervoor API aanroepen als volgt aan:
api.postcode.nl/rest/addresses/2012es/30
api.postcode.nl/rest/addresses/postcode/2012es/30

worden: api.postcode.eu/nl/v1/addresses/postcode/2012es/30
